### PR TITLE
feat: backend env templates and seed data bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+## Root environment example
+# Supabase
+SUPABASE_URL="https://your-project.supabase.co"
+SUPABASE_ANON_KEY="your-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+SUPABASE_JWT_SECRET="your-supabase-jwt-secret"
+
+# Database (Supabase Postgres connection string)
+DATABASE_URL="postgresql://postgres:password@db.supabase.co:5432/postgres"
+
+# Redis
+REDIS_URL="redis://localhost:6379"
+
+# Backend service
+PORT=4000
+API_BASE_URL="http://localhost:4000"
+WS_URL="ws://localhost:4000"
+JWT_AUDIENCE="authenticated"
+
+# Test conveniences (optional)
+API_BEARER_TOKEN=""
+API_TEST_TABLE_ID=""

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!backend/.env.example
 
 # vercel
 .vercel

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,21 @@
+# Supabase
+SUPABASE_URL="https://your-project.supabase.co"
+SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
+SUPABASE_JWT_SECRET="your-supabase-jwt-secret"
+
+# Database (Supabase Postgres connection string)
+DATABASE_URL="postgresql://postgres:password@db.supabase.co:5432/postgres"
+
+# Redis
+REDIS_URL="redis://localhost:6379"
+
+# Server
+PORT=4000
+NODE_ENV=development
+API_BASE_URL="http://localhost:4000"
+WS_URL="ws://localhost:4000"
+JWT_AUDIENCE="authenticated"
+
+# Test conveniences (optional)
+API_BEARER_TOKEN=""
+API_TEST_TABLE_ID=""

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,33 +4,23 @@ Texas Hold'em Home Game Platform Backend
 
 ## Setup
 
-1. Install dependencies:
+1. (Optional) Run the one-command bootstrap from repo root:
 ```bash
+./scripts/bootstrap-local.sh
+```
+
+2. Or do it manually:
+```bash
+cp ../.env.example ../.env
+cp .env.example .env
 npm install
-```
-
-2. Set up environment variables in `.env`:
-```env
-# Supabase
-SUPABASE_URL=https://<your>.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
-SUPABASE_JWT_SECRET=<supabase-jwt-secret>
-
-# Postgres (Supabase DB)
-DATABASE_URL=postgresql://postgres:<password>@db.<domain>.supabase.co:5432/postgres
-
-# Redis
-REDIS_URL=redis://localhost:6379
-
-# Backend
-PORT=4000
-NODE_ENV=development
-```
-
-3. Set up Prisma:
-```bash
 npm run prisma:generate
 npm run prisma:migrate
+```
+
+3. Seed demo data (two users + one table):
+```bash
+npm run seed
 ```
 
 4. Start the server:
@@ -62,4 +52,3 @@ See `/docs/specs/rest-api-spec.md` for full API documentation.
 ## WebSocket Protocol
 
 See `/docs/specs/web-socket-protocol.md` for WebSocket message format.
-

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
+    "seed": "ts-node scripts/seed.ts",
     "test": "vitest --watch=false",
     "test:integration": "playwright test tests/integration",
     "test:ws": "playwright test tests/websocket",
@@ -22,6 +23,7 @@
     "@fastify/cors": "^9.0.1",
     "@prisma/client": "^5.19.1",
     "@supabase/supabase-js": "^2.45.4",
+    "crypto": "^1.0.1",
     "dotenv": "^16.4.5",
     "fastify": "^4.28.1",
     "ioredis": "^5.4.1",
@@ -30,14 +32,14 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.2",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.14.12",
     "nodemon": "^3.1.4",
     "prisma": "^5.19.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
-    "@playwright/test": "^1.48.2",
-    "ws": "^8.18.0",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "ws": "^8.18.0"
   }
 }

--- a/backend/scripts/seed.ts
+++ b/backend/scripts/seed.ts
@@ -1,0 +1,100 @@
+import "dotenv/config";
+import { randomUUID } from "crypto";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const DEMO_USERS = [
+  { id: "11111111-1111-1111-1111-111111111111", displayName: "Alice Demo" },
+  { id: "22222222-2222-2222-2222-222222222222", displayName: "Bob Demo" },
+] as const;
+
+const DEMO_TABLE = {
+  inviteCode: "DEMO123",
+  name: "Demo Home Game",
+  maxPlayers: 6,
+  smallBlind: 5,
+  bigBlind: 10,
+  status: "OPEN" as const,
+};
+
+async function upsertProfiles() {
+  for (const user of DEMO_USERS) {
+    await prisma.profile.upsert({
+      where: { id: user.id },
+      update: { displayName: user.displayName },
+      create: { id: user.id, displayName: user.displayName },
+    });
+  }
+}
+
+async function upsertTable() {
+  return prisma.table.upsert({
+    where: { inviteCode: DEMO_TABLE.inviteCode },
+    update: {
+      hostUserId: DEMO_USERS[0].id,
+      name: DEMO_TABLE.name,
+      maxPlayers: DEMO_TABLE.maxPlayers,
+      smallBlind: DEMO_TABLE.smallBlind,
+      bigBlind: DEMO_TABLE.bigBlind,
+      status: DEMO_TABLE.status,
+    },
+    create: {
+      id: randomUUID(),
+      inviteCode: DEMO_TABLE.inviteCode,
+      hostUserId: DEMO_USERS[0].id,
+      name: DEMO_TABLE.name,
+      maxPlayers: DEMO_TABLE.maxPlayers,
+      smallBlind: DEMO_TABLE.smallBlind,
+      bigBlind: DEMO_TABLE.bigBlind,
+      status: DEMO_TABLE.status,
+    },
+  });
+}
+
+async function upsertSeats(tableId: string) {
+  const seats = [
+    { seatIndex: 0, userId: DEMO_USERS[0].id, stack: 1000 },
+    { seatIndex: 1, userId: DEMO_USERS[1].id, stack: 1000 },
+  ];
+
+  for (const seat of seats) {
+    await prisma.seat.upsert({
+      where: {
+        tableId_seatIndex: { tableId, seatIndex: seat.seatIndex },
+      },
+      update: {
+        userId: seat.userId,
+        stack: seat.stack,
+        isSittingOut: false,
+      },
+      create: {
+        tableId,
+        seatIndex: seat.seatIndex,
+        userId: seat.userId,
+        stack: seat.stack,
+        isSittingOut: false,
+      },
+    });
+  }
+}
+
+async function main() {
+  console.log("Seeding demo data...");
+  await upsertProfiles();
+  const table = await upsertTable();
+  await upsertSeats(table.id);
+
+  console.log("Seed complete:");
+  console.log(`- Users: ${DEMO_USERS.map((u) => `${u.displayName} (${u.id})`).join(", ")}`);
+  console.log(`- Table: ${table.name} (invite code: ${table.inviteCode}, id: ${table.id})`);
+}
+
+main()
+  .catch((err) => {
+    console.error("Seed failed:", err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+copy_if_missing() {
+  local src="$1"
+  local dest="$2"
+  if [[ ! -f "$dest" ]]; then
+    echo "Creating $(realpath --relative-to="$ROOT_DIR" "$dest") from template"
+    cp "$src" "$dest"
+  else
+    echo "Skipping $(realpath --relative-to="$ROOT_DIR" "$dest") (already exists)"
+  fi
+}
+
+# 1) Ensure env files exist
+copy_if_missing "$ROOT_DIR/.env.example" "$ROOT_DIR/.env"
+copy_if_missing "$ROOT_DIR/backend/.env.example" "$ROOT_DIR/backend/.env"
+
+# 2) Install dependencies and generate Prisma client
+echo "Installing backend dependencies..."
+(cd "$ROOT_DIR/backend" && npm install && npm run prisma:generate)
+
+if [[ -d "$ROOT_DIR/frontend" ]]; then
+  echo "Installing frontend dependencies..."
+  (cd "$ROOT_DIR/frontend" && npm install)
+fi
+
+echo "Bootstrap complete. Update any placeholder values in .env files before running the app."


### PR DESCRIPTION
## Summary
- add root and backend `.env.example` files with Supabase/Postgres/Redis/service/test variables
- provide bootstrap script to copy env templates and install deps + Prisma client
- add demo seed script (two users + one table with seats) and npm `seed` script; document flow in backend README

## Testing
- not run (requires configured Supabase/Postgres/Redis)

Closes #1