### PR TITLE
feat: gameplay loop orchestration (manual start + auto next hand)

### DIFF
--- a/backend/src/ws/schemas.ts
+++ b/backend/src/ws/schemas.ts
@@ -35,9 +35,14 @@ export const chatSendSchema = z.object({
   content: z.string().min(1).max(256),
 });
 
+export const gameStartSchema = z.object({
+  tableId: uuid(),
+});
+
 export type JoinTableInput = z.infer<typeof joinTableSchema>;
 export type LeaveTableInput = z.infer<typeof leaveTableSchema>;
 export type SitDownInput = z.infer<typeof sitDownSchema>;
 export type StandUpInput = z.infer<typeof standUpSchema>;
 export type PlayerActionInput = z.infer<typeof playerActionSchema>;
 export type ChatSendInput = z.infer<typeof chatSendSchema>;
+export type GameStartInput = z.infer<typeof gameStartSchema>;

--- a/frontend/hooks/useTableState.ts
+++ b/frontend/hooks/useTableState.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import type { TableState } from "@/lib/types";
 import { useWebSocket } from "./useWebSocket";
 
 export function useTableState(tableId: string) {
   const [tableState, setTableState] = useState<TableState | null>(null);
-  const { socket, connected, on } = useWebSocket(tableId);
+  const { socket, connected, on, emit } = useWebSocket(tableId);
 
   useEffect(() => {
     if (!socket || !connected) return;
@@ -30,5 +30,11 @@ export function useTableState(tableId: string) {
     };
   }, [socket, connected, on]);
 
-  return { tableState, connected };
+  const startGame = useCallback(() => {
+    if (connected) {
+      emit("GAME_START", { tableId });
+    }
+  }, [connected, emit, tableId]);
+
+  return { tableState, connected, startGame };
 }


### PR DESCRIPTION
## Summary
- Add GAME_START host-only WebSocket event and zod validation; mark table in-game and start first hand
- Auto-start subsequent hands after HAND_COMPLETE with 2s cooldown; initialize Redis state from DB when missing
- Add turn-timeout stub for future auto-fold; expose startGame hook on frontend and align schemas

## Testing
- Not run (WS/game flow requires backend runtime with Redis + DB)

Closes #3