### PR TITLE
feat: auth membership guardrails and WS/REST rate limits

### DIFF
--- a/backend/src/api/tables.controller.ts
+++ b/backend/src/api/tables.controller.ts
@@ -82,6 +82,8 @@ export async function registerTableRoutes(app: FastifyInstance) {
     "/:id",
     { preHandler: authenticate },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      const req = request as AuthenticatedRequest;
+      const userId = req.userId;
       const params = request.params as { id: string };
       const table = await getTableById(params.id);
 
@@ -90,6 +92,17 @@ export async function registerTableRoutes(app: FastifyInstance) {
           error: {
             code: "TABLE_NOT_FOUND",
             message: "Table does not exist.",
+          },
+        });
+      }
+
+      const isHost = table.hostUserId === userId;
+      const isMember = table.seats.some((s) => s.userId === userId);
+      if (!isHost && !isMember) {
+        return reply.status(403).send({
+          error: {
+            code: "NOT_IN_TABLE",
+            message: "You are not a member of this table.",
           },
         });
       }
@@ -239,4 +252,3 @@ export async function registerTableRoutes(app: FastifyInstance) {
     }
   );
 }
-

--- a/backend/src/utils/rateLimiter.ts
+++ b/backend/src/utils/rateLimiter.ts
@@ -1,0 +1,29 @@
+type RateLimitState = { count: number; resetAt: number };
+
+export interface RateLimitConfig {
+  windowMs: number;
+  max: number;
+}
+
+const buckets = new Map<string, RateLimitState>();
+
+export function checkRateLimit(key: string, config: RateLimitConfig): boolean {
+  const now = Date.now();
+  const existing = buckets.get(key);
+
+  if (!existing || now > existing.resetAt) {
+    buckets.set(key, { count: 1, resetAt: now + config.windowMs });
+    return true;
+  }
+
+  if (existing.count >= config.max) {
+    return false;
+  }
+
+  existing.count += 1;
+  return true;
+}
+
+export function resetRateLimit(key: string) {
+  buckets.delete(key);
+}


### PR DESCRIPTION
## Summary
- Enforce host/member access on GET /tables/:id with NOT_IN_TABLE 403 response
- Add reusable rate limiter helper and apply configurable chat/action rate limits in WebSocket handlers
- WS guards: host/member checks remain on JOIN_TABLE, chat keeps membership validation, and ACTION_RATE_LIMIT added for player actions

## Testing
- Not run (WS/REST manual testing recommended with valid tokens)

Closes #5