### PR TITLE
feat: frontend auth and lobby flows

### DIFF
--- a/frontend/app/lobby/page.tsx
+++ b/frontend/app/lobby/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/useAuth";
@@ -71,13 +71,14 @@ export default function LobbyPage() {
     }
   };
 
-  if (authLoading) {
-    return <div className="text-center text-slate-400">Loading...</div>;
-  }
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push("/auth/login");
+    }
+  }, [authLoading, user, router]);
 
-  if (!user) {
-    router.push("/auth/login");
-    return null;
+  if (authLoading || !user) {
+    return <div className="text-center text-slate-400">Loading...</div>;
   }
 
   return (

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -16,8 +16,11 @@ export function useAuth() {
         session?.user
           ? {
               id: session.user.id,
-              email: session.user.email,
-              displayName: session.user.user_metadata?.display_name,
+              email: session.user.email || undefined,
+              displayName:
+                session.user.user_metadata?.display_name ||
+                session.user.email ||
+                undefined,
             }
           : null
       );
@@ -30,8 +33,11 @@ export function useAuth() {
         data.session?.user
           ? {
               id: data.session.user.id,
-              email: data.session.user.email,
-              displayName: data.session.user.user_metadata?.display_name,
+              email: data.session.user.email || undefined,
+              displayName:
+                data.session.user.user_metadata?.display_name ||
+                data.session.user.email ||
+                undefined,
             }
           : null
       );
@@ -50,5 +56,3 @@ export function useAuth() {
 
   return { user, loading, signOut };
 }
-
-

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -8,13 +8,21 @@ export interface User {
 
 export interface Table {
   id: string;
+  hostUserId: string;
   name: string;
-  hostId: string;
   status: "OPEN" | "IN_GAME" | "CLOSED";
-  playerCount: number;
+  maxPlayers: number;
+  smallBlind: number;
+  bigBlind: number;
   inviteCode: string;
   createdAt: string;
-  updatedAt: string;
+  seats?: {
+    seatIndex: number;
+    userId: string | null;
+    displayName: string | null;
+    stack: number;
+    isSittingOut: boolean;
+  }[];
 }
 
 export interface TableState {
@@ -65,5 +73,3 @@ export interface DashboardProgression {
   netChips: number;
   hands: number;
 }
-
-


### PR DESCRIPTION
## Summary
- Implemented lobby page with “My Tables” list, create-table modal (name/maxPlayers/blinds), and join-by-code flow hitting `/api/tables/my-tables`, `/api/tables`, and `/api/tables/join-by-code`
- Tightened front-end types and API client: typed ApiError, safer response parsing, Table type aligned to backend fields
- useAuth now falls back to email when display_name is absent

## Testing
- Not run (Next.js frontend; manual auth + lobby smoke test recommended)

Closes #6