### PR TITLE
feat: implement milestone 7 table page UI

### DIFF
--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -31,7 +31,7 @@ export default function LoginPage() {
       } else {
         router.push("/lobby");
       }
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred");
     } finally {
       setLoading(false);
@@ -80,5 +80,3 @@ export default function LoginPage() {
     </div>
   );
 }
-
-

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -37,7 +37,7 @@ export default function RegisterPage() {
       } else {
         router.push("/lobby");
       }
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred");
     } finally {
       setLoading(false);
@@ -95,5 +95,3 @@ export default function RegisterPage() {
     </div>
   );
 }
-
-

--- a/frontend/components/table/HandResultOverlay.tsx
+++ b/frontend/components/table/HandResultOverlay.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Button } from "@/components/ui/Button";
+import type { HandResultEvent, PublicSeatView } from "@/lib/types";
+
+interface HandResultOverlayProps {
+  result: HandResultEvent;
+  seats: PublicSeatView[];
+  onClose: () => void;
+}
+
+export function HandResultOverlay({ result, seats, onClose }: HandResultOverlayProps) {
+  const lookupName = (seatIndex: number) =>
+    seats.find((s) => s.seatIndex === seatIndex)?.displayName || `Seat ${seatIndex + 1}`;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-slate-900 border border-slate-700 rounded-xl p-6 shadow-2xl w-full max-w-lg">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-slate-50">Hand Result</h3>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          {result.winners.map((winner) => (
+            <div
+              key={`${result.handId}-${winner.seatIndex}`}
+              className="border border-emerald-700 bg-emerald-900/40 rounded-lg p-3"
+            >
+              <div className="flex justify-between text-sm text-slate-100">
+                <span>{lookupName(winner.seatIndex)}</span>
+                <span className="text-emerald-300 font-semibold">+{winner.wonAmount}</span>
+              </div>
+              <div className="text-xs text-slate-300">
+                {winner.handRank} • {winner.handDescription}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 text-xs text-slate-400">Hand ID: {result.handId}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/table/PlayerSeat.tsx
+++ b/frontend/components/table/PlayerSeat.tsx
@@ -1,23 +1,19 @@
 "use client";
 
-import type { PlayerState } from "@/lib/types";
+import type { PublicSeatView } from "@/lib/types";
 
 interface PlayerSeatProps {
-  player: PlayerState;
+  seat: PublicSeatView;
   position: number;
   totalSeats: number;
-  isCurrentUser: boolean;
   isActive: boolean;
-  isDealer: boolean;
 }
 
 export function PlayerSeat({
-  player,
+  seat,
   position,
   totalSeats,
-  isCurrentUser,
   isActive,
-  isDealer,
 }: PlayerSeatProps) {
   // Calculate position around the table (circular layout)
   const angle = (position / totalSeats) * 2 * Math.PI - Math.PI / 2;
@@ -35,29 +31,28 @@ export function PlayerSeat({
     >
       <div
         className={`p-3 rounded-lg border-2 min-w-[120px] ${
-          isCurrentUser
+          seat.isSelf
             ? "bg-emerald-800 border-emerald-500"
             : "bg-slate-800 border-slate-600"
         } ${isActive ? "ring-2 ring-yellow-400" : ""}`}
       >
-        {isDealer && (
-          <div className="absolute -top-2 -right-2 bg-yellow-500 text-slate-900 text-xs font-bold px-2 py-1 rounded-full">
-            D
-          </div>
-        )}
         <div className="text-sm font-semibold text-slate-50">
-          Player {position + 1}
+          {seat.displayName || `Seat ${position + 1}`}
         </div>
-        <div className="text-xs text-slate-300">Chips: {player.chips}</div>
-        {player.bet > 0 && (
-          <div className="text-xs text-yellow-400">Bet: {player.bet}</div>
-        )}
-        {player.isAllIn && (
+        <div className="text-xs text-slate-300">Chips: {seat.stack}</div>
+        {seat.status === "ALL_IN" && (
           <div className="text-xs text-red-400 font-bold">ALL IN</div>
+        )}
+        {seat.status === "FOLDED" && (
+          <div className="text-xs text-slate-400">Folded</div>
+        )}
+        {seat.status === "SITTING_OUT" && (
+          <div className="text-xs text-orange-300">Sitting out</div>
+        )}
+        {seat.isSelf && seat.status === "ACTIVE" && (
+          <div className="text-xs text-emerald-200">You</div>
         )}
       </div>
     </div>
   );
 }
-
-

--- a/frontend/components/table/PokerTable.tsx
+++ b/frontend/components/table/PokerTable.tsx
@@ -3,14 +3,14 @@
 import { PlayerSeat } from "./PlayerSeat";
 import { CommunityCards } from "./CommunityCards";
 import { PotDisplay } from "./PotDisplay";
-import type { TableState } from "@/lib/types";
+import type { PublicTableView, Table } from "@/lib/types";
 
 interface PokerTableProps {
-  tableState: TableState;
-  currentUserId: string;
+  tableState: PublicTableView;
+  tableMeta: Table;
 }
 
-export function PokerTable({ tableState, currentUserId }: PokerTableProps) {
+export function PokerTable({ tableState, tableMeta }: PokerTableProps) {
   return (
     <div className="relative w-full max-w-4xl mx-auto aspect-[4/3]">
       {/* Table surface */}
@@ -18,20 +18,18 @@ export function PokerTable({ tableState, currentUserId }: PokerTableProps) {
         {/* Community cards and pot in center */}
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           <CommunityCards cards={tableState.communityCards} />
-          <PotDisplay pot={tableState.pot} />
+          <PotDisplay potTotal={tableState.potTotal} />
         </div>
 
         {/* Player seats arranged in a circle */}
         <div className="absolute inset-0">
-          {tableState.players.map((player) => (
+          {tableState.seats.map((seat) => (
             <PlayerSeat
-              key={player.userId}
-              player={player}
-              position={player.position}
-              totalSeats={tableState.players.length}
-              isCurrentUser={player.userId === currentUserId}
-              isActive={player.position === tableState.activePlayerPosition}
-              isDealer={player.position === tableState.dealerPosition}
+              key={seat.seatIndex}
+              seat={seat}
+              position={seat.seatIndex}
+              totalSeats={tableMeta.maxPlayers}
+              isActive={tableState.toActSeatIndex === seat.seatIndex}
             />
           ))}
         </div>
@@ -39,5 +37,3 @@ export function PokerTable({ tableState, currentUserId }: PokerTableProps) {
     </div>
   );
 }
-
-

--- a/frontend/components/table/PotDisplay.tsx
+++ b/frontend/components/table/PotDisplay.tsx
@@ -1,16 +1,14 @@
 "use client";
 
 interface PotDisplayProps {
-  pot: number;
+  potTotal: number;
 }
 
-export function PotDisplay({ pot }: PotDisplayProps) {
+export function PotDisplay({ potTotal }: PotDisplayProps) {
   return (
     <div className="bg-slate-900 border-2 border-yellow-500 rounded-lg px-6 py-3">
       <div className="text-sm text-slate-400">Pot</div>
-      <div className="text-2xl font-bold text-yellow-400">{pot}</div>
+      <div className="text-2xl font-bold text-yellow-400">{potTotal}</div>
     </div>
   );
 }
-
-

--- a/frontend/components/table/TableHud.tsx
+++ b/frontend/components/table/TableHud.tsx
@@ -1,37 +1,34 @@
 "use client";
 
-import type { TableState } from "@/lib/types";
+import type { PublicTableView, Table } from "@/lib/types";
 
 interface TableHudProps {
   tableName: string;
-  tableState: TableState;
+  tableMeta: Table;
+  tableState: PublicTableView;
 }
 
-export function TableHud({ tableName, tableState }: TableHudProps) {
+export function TableHud({ tableName, tableMeta, tableState }: TableHudProps) {
   return (
     <div className="bg-slate-800 border border-slate-700 rounded-lg p-4 mb-4">
       <div className="flex justify-between items-center">
         <div>
           <h2 className="text-xl font-semibold text-slate-50">{tableName}</h2>
-          <p className="text-sm text-slate-400">Hand #{tableState.handNumber}</p>
+          <p className="text-sm text-slate-400">Blinds {tableMeta.smallBlind}/{tableMeta.bigBlind}</p>
         </div>
         <div className="flex gap-6 text-sm">
           <div>
-            <span className="text-slate-400">Blinds: </span>
+            <span className="text-slate-400">Street: </span>
             <span className="text-slate-50 font-semibold">
-              {tableState.smallBlind}/{tableState.bigBlind}
+              {tableState.street ?? "WAITING"}
             </span>
           </div>
           <div>
-            <span className="text-slate-400">Street: </span>
-            <span className="text-slate-50 font-semibold">
-              {tableState.currentStreet}
-            </span>
+            <span className="text-slate-400">Pot: </span>
+            <span className="text-slate-50 font-semibold">{tableState.potTotal}</span>
           </div>
         </div>
       </div>
     </div>
   );
 }
-
-

--- a/frontend/hooks/useTableState.ts
+++ b/frontend/hooks/useTableState.ts
@@ -1,34 +1,72 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import type { TableState } from "@/lib/types";
+import type { HandResultEvent, PublicTableView } from "@/lib/types";
 import { useWebSocket } from "./useWebSocket";
 
 export function useTableState(tableId: string) {
-  const [tableState, setTableState] = useState<TableState | null>(null);
+  const [tableState, setTableState] = useState<PublicTableView | null>(null);
+  const [handResult, setHandResult] = useState<HandResultEvent | null>(null);
   const { socket, connected, on, emit } = useWebSocket(tableId);
 
   useEffect(() => {
     if (!socket || !connected) return;
 
-    const unsubscribeTableState = on("TABLE_STATE", (payload: { state?: TableState }) => {
-      setTableState(payload.state ?? (payload as unknown as TableState));
-    });
+    const unsubscribeTableState = on(
+      "TABLE_STATE",
+      (payload: { state?: PublicTableView; tableId: string }) => {
+        const nextState = payload.state ?? (payload as unknown as PublicTableView);
+        setTableState(() => {
+          // Clear stale hand results when a new hand arrives
+          if (handResult && handResult.handId !== nextState.handId) {
+            setHandResult(null);
+          }
+          return nextState;
+        });
+      }
+    );
 
-    const unsubscribeActionTaken = on("ACTION_TAKEN", () => {
-      // ACTION_TAKEN broadcasts accompany a later TABLE_STATE; no-op here
-    });
+    const unsubscribeHandResult = on(
+      "HAND_RESULT",
+      (payload: { handId: string; results: HandResultEvent["winners"]; finalStacks: HandResultEvent["finalStacks"] }) => {
+        setHandResult({
+          handId: payload.handId,
+          winners: payload.results,
+          finalStacks: payload.finalStacks,
+        });
 
-    const unsubscribeHandResult = on("HAND_RESULT", () => {
-      // HAND_RESULT handled via TABLE_STATE update
-    });
+        // Update chip stacks eagerly so UI reflects results before next snapshot
+        setTableState((prev) => {
+          if (!prev) return prev;
+          const updatedSeats = prev.seats.map((seat) => {
+            const finalStack = payload.finalStacks.find((fs) => fs.seatIndex === seat.seatIndex);
+            return finalStack ? { ...seat, stack: finalStack.stack } : seat;
+          });
+          return { ...prev, seats: updatedSeats };
+        });
+      }
+    );
+
+    const unsubscribeHoleCards = on(
+      "HOLE_CARDS",
+      (payload: { tableId: string; handId: string; cards: string[] }) => {
+        setTableState((prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            handId: payload.handId,
+            holeCards: payload.cards,
+          };
+        });
+      }
+    );
 
     return () => {
       unsubscribeTableState?.();
-      unsubscribeActionTaken?.();
       unsubscribeHandResult?.();
+      unsubscribeHoleCards?.();
     };
-  }, [socket, connected, on]);
+  }, [socket, connected, on, handResult]);
 
   const startGame = useCallback(() => {
     if (connected) {
@@ -36,5 +74,5 @@ export function useTableState(tableId: string) {
     }
   }, [connected, emit, tableId]);
 
-  return { tableState, connected, startGame };
+  return { tableState, handResult, clearHandResult: () => setHandResult(null), connected, startGame };
 }

--- a/frontend/hooks/useWebSocket.ts
+++ b/frontend/hooks/useWebSocket.ts
@@ -59,7 +59,7 @@ export function useWebSocket(tableId?: string) {
   }, [tableId]);
 
   const emit = useCallback(
-    (event: string, data?: any) => {
+    (event: string, data?: unknown) => {
       if (socket && connected) {
         socket.emit(event, data);
       }
@@ -68,7 +68,7 @@ export function useWebSocket(tableId?: string) {
   );
 
   const on = useCallback(
-    (event: string, handler: (...args: any[]) => void) => {
+    (event: string, handler: (...args: unknown[]) => void) => {
       if (socket) {
         socket.on(event, handler);
         return () => {

--- a/frontend/lib/apiClient.ts
+++ b/frontend/lib/apiClient.ts
@@ -38,11 +38,12 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   });
 
   const text = await res.text();
-  const data = text ? JSON.parse(text) : null;
+  const data = text ? (JSON.parse(text) as unknown) : null;
 
   if (!res.ok) {
-    const code = data?.error?.code;
-    const message = data?.error?.message || res.statusText;
+    const errorPayload = data as { error?: { code?: string; message?: string } } | null;
+    const code = errorPayload?.error?.code;
+    const message = errorPayload?.error?.message || res.statusText;
     throw new ApiError(message, code, res.status);
   }
 
@@ -51,12 +52,12 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 
 export const apiClient = {
   get: <T>(path: string) => request<T>(path),
-  post: <T>(path: string, body?: any) =>
+  post: <T>(path: string, body?: unknown) =>
     request<T>(path, {
       method: "POST",
       body: JSON.stringify(body || {}),
     }),
-  put: <T>(path: string, body?: any) =>
+  put: <T>(path: string, body?: unknown) =>
     request<T>(path, {
       method: "PUT",
       body: JSON.stringify(body || {}),

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -16,38 +16,62 @@ export interface Table {
   bigBlind: number;
   inviteCode: string;
   createdAt: string;
-  seats?: {
-    seatIndex: number;
-    userId: string | null;
-    displayName: string | null;
-    stack: number;
-    isSittingOut: boolean;
-  }[];
+  seats?: TableSeat[];
 }
 
-export interface TableState {
+export type SeatStatus = "ACTIVE" | "FOLDED" | "ALL_IN" | "SITTING_OUT";
+
+export type Street =
+  | "WAITING"
+  | "DEALING"
+  | "PREFLOP"
+  | "FLOP"
+  | "TURN"
+  | "RIVER"
+  | "SHOWDOWN"
+  | "COMPLETE";
+
+export interface TableSeat {
+  seatIndex: number;
+  userId: string | null;
+  displayName: string | null;
+  stack: number;
+  isSittingOut: boolean;
+}
+
+export interface PublicSeatView {
+  seatIndex: number;
+  displayName: string;
+  stack: number;
+  status: SeatStatus;
+  isSelf: boolean;
+}
+
+export interface PublicTableView {
   tableId: string;
-  handNumber: number;
-  currentStreet: "PREFLOP" | "FLOP" | "TURN" | "RIVER" | "SHOWDOWN";
+  seats: PublicSeatView[];
   communityCards: string[];
-  pot: number;
-  currentBet: number;
-  smallBlind: number;
-  bigBlind: number;
-  dealerPosition: number;
-  activePlayerPosition?: number;
-  players: PlayerState[];
+  potTotal: number;
+  street: Street | null;
+  toActSeatIndex?: number;
+  minBet?: number;
+  callAmount?: number;
+  handId?: string;
+  holeCards?: string[];
 }
 
-export interface PlayerState {
-  userId: string;
-  position: number;
-  chips: number;
-  bet: number;
-  isActive: boolean;
-  isAllIn: boolean;
-  hasActed: boolean;
-  holeCards?: string[];
+export interface HandResultEvent {
+  handId: string;
+  winners: Array<{
+    seatIndex: number;
+    handRank: string;
+    handDescription: string;
+    wonAmount: number;
+  }>;
+  finalStacks: Array<{
+    seatIndex: number;
+    stack: number;
+  }>;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary
- align frontend public table types with backend public table view (seats, streets, pots)
- implement table page wiring to WS snapshot/events with client validation and action controls
- add hand-result overlay, highlight turn state, and clean up linting

## Testing
- frontend: npm run lint