### PR TITLE
feat: add password reset request and confirm flows

### DIFF
--- a/backend/src/api/auth.controller.ts
+++ b/backend/src/api/auth.controller.ts
@@ -1,6 +1,11 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { z } from "zod";
 import { authenticate, AuthenticatedRequest } from "../middleware/auth";
-import { getUserProfile } from "../services/auth.service";
+import {
+  getUserProfile,
+  requestPasswordReset,
+  confirmPasswordReset,
+} from "../services/auth.service";
 
 export async function registerAuthRoutes(app: FastifyInstance) {
   app.get("/me", { preHandler: authenticate }, async (request: FastifyRequest, reply: FastifyReply) => {
@@ -25,5 +30,62 @@ export async function registerAuthRoutes(app: FastifyInstance) {
       createdAt: profile.createdAt.toISOString(),
     });
   });
-}
 
+  app.post("/password-reset/request", async (request: FastifyRequest, reply: FastifyReply) => {
+    const bodySchema = z.object({
+      email: z.string().email(),
+    });
+
+    let email: string;
+    try {
+      ({ email } = bodySchema.parse(request.body));
+    } catch (err) {
+      return reply.status(400).send({
+        error: { code: "INVALID_EMAIL", message: "A valid email is required." },
+      });
+    }
+
+    try {
+      await requestPasswordReset(email);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message === "RESET_RATE_LIMIT") {
+        return reply.status(429).send({
+          error: { code: "RESET_RATE_LIMIT", message: "Too many requests. Please try again later." },
+        });
+      }
+      // Always return generic success to avoid user enumeration
+    }
+
+    return reply.send({ status: "ok" });
+  });
+
+  app.post("/password-reset/confirm", async (request: FastifyRequest, reply: FastifyReply) => {
+    const bodySchema = z.object({
+      token: z.string().min(1),
+      newPassword: z.string().min(6),
+    });
+
+    let parsed: { token: string; newPassword: string };
+    try {
+      parsed = bodySchema.parse(request.body);
+    } catch (err) {
+      return reply.status(400).send({
+        error: { code: "INVALID_PAYLOAD", message: "Token and a 6+ character password are required." },
+      });
+    }
+
+    try {
+      await confirmPasswordReset(parsed.token, parsed.newPassword);
+      return reply.send({ status: "ok" });
+    } catch (err) {
+      if (err instanceof Error && err.message === "RESET_RATE_LIMIT") {
+        return reply.status(429).send({
+          error: { code: "RESET_RATE_LIMIT", message: "Too many attempts. Please try again later." },
+        });
+      }
+      return reply.status(400).send({
+        error: { code: "RESET_CONFIRM_FAILED", message: "Could not reset password. The link may be invalid or expired." },
+      });
+    }
+  });
+}

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -7,6 +7,7 @@ export const env = {
   SUPABASE_URL: process.env.SUPABASE_URL || "",
   SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY || "",
   SUPABASE_JWT_SECRET: process.env.SUPABASE_JWT_SECRET || "",
+  PASSWORD_RESET_REDIRECT_URL: process.env.PASSWORD_RESET_REDIRECT_URL || "",
 
   // Database
   DATABASE_URL: process.env.DATABASE_URL || "",
@@ -31,4 +32,3 @@ for (const envVar of requiredEnvVars) {
     throw new Error(`Missing required environment variable: ${envVar}`);
   }
 }
-

--- a/backend/src/config/supabase.ts
+++ b/backend/src/config/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from "@supabase/supabase-js";
+import { env } from "./env";
+
+export const supabaseAdmin = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,4 +1,8 @@
 import { prisma } from "../db/prisma";
+import { supabaseAdmin } from "../config/supabase";
+import { env } from "../config/env";
+import { verifyAccessToken } from "../config/auth";
+import { checkRateLimit } from "../utils/rateLimiter";
 
 export interface UserProfile {
   id: string;
@@ -48,3 +52,54 @@ export async function getOrCreateProfile(
   };
 }
 
+export async function requestPasswordReset(email: string) {
+  const rlKey = `pwdreset:req:${email.toLowerCase()}`;
+  if (
+    !checkRateLimit(rlKey, {
+      windowMs: Number(process.env.PASSWORD_RESET_RATE_LIMIT_MS || 5 * 60 * 1000),
+      max: Number(process.env.PASSWORD_RESET_RATE_LIMIT_MAX || 5),
+    })
+  ) {
+    throw new Error("RESET_RATE_LIMIT");
+  }
+
+  const redirectTo = env.PASSWORD_RESET_REDIRECT_URL || undefined;
+  const { error } = await supabaseAdmin.auth.resetPasswordForEmail(email, { redirectTo });
+  if (error) {
+    // Intentionally generic to avoid user enumeration
+    throw new Error("RESET_REQUEST_FAILED");
+  }
+}
+
+export async function confirmPasswordReset(token: string, newPassword: string) {
+  // Validate token with the Supabase JWT secret to extract the user id
+  const payload = verifyAccessToken(token);
+  if (!payload.sub) {
+    throw new Error("INVALID_TOKEN");
+  }
+
+  const rlKey = `pwdreset:confirm:${payload.sub}`;
+  if (
+    !checkRateLimit(rlKey, {
+      windowMs: Number(process.env.PASSWORD_RESET_CONFIRM_RATE_LIMIT_MS || 5 * 60 * 1000),
+      max: Number(process.env.PASSWORD_RESET_CONFIRM_RATE_LIMIT_MAX || 5),
+    })
+  ) {
+    throw new Error("RESET_RATE_LIMIT");
+  }
+
+  const { error } = await supabaseAdmin.auth.admin.updateUserById(payload.sub, {
+    password: newPassword,
+  });
+
+  if (error) {
+    throw new Error("RESET_CONFIRM_FAILED");
+  }
+
+  // Optionally ensure a profile exists
+  await prisma.profile.upsert({
+    where: { id: payload.sub },
+    update: { updatedAt: new Date() },
+    create: { id: payload.sub, displayName: payload.email || `player-${payload.sub.slice(0, 8)}` },
+  });
+}

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -66,6 +66,11 @@ export default function LoginPage() {
               {error}
             </div>
           )}
+          <div className="flex justify-end text-sm">
+            <Link href="/auth/reset" className="text-emerald-400 hover:underline">
+              Forgot password?
+            </Link>
+          </div>
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? "Logging in..." : "Log In"}
           </Button>

--- a/frontend/app/auth/reset/confirm/page.tsx
+++ b/frontend/app/auth/reset/confirm/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { supabase } from "@/lib/supabaseClient";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+
+export default function ResetConfirmPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const code = searchParams.get("code");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [sessionReady, setSessionReady] = useState(false);
+
+  useEffect(() => {
+    const exchange = async () => {
+      if (!code) {
+        setError("Missing or invalid reset link.");
+        return;
+      }
+      const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
+      if (exchangeError) {
+        setError("This reset link is invalid or expired.");
+      } else {
+        setSessionReady(true);
+      }
+    };
+    exchange();
+  }, [code]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!sessionReady) return;
+    if (password.length < 6) {
+      setError("Password must be at least 6 characters.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const { error: updateError } = await supabase.auth.updateUser({ password });
+    if (updateError) {
+      setError("Could not update password. Please try again.");
+    } else {
+      setSuccess(true);
+      setTimeout(() => router.push("/auth/login"), 1500);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-12">
+      <Card>
+        <h1 className="text-3xl font-bold text-slate-50 mb-6 text-center">Set a new password</h1>
+        {success ? (
+          <div className="space-y-3 text-slate-200 text-center">
+            <p>Password updated. Redirecting to login...</p>
+            <Link href="/auth/login" className="text-emerald-400 hover:underline">
+              Go to login now
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="password"
+              label="New password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={loading || !sessionReady}
+              minLength={6}
+              required
+            />
+            <Input
+              type="password"
+              label="Confirm password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              disabled={loading || !sessionReady}
+              minLength={6}
+              required
+            />
+            {error && (
+              <div className="p-3 bg-red-900/50 border border-red-700 rounded-lg text-red-300 text-sm">
+                {error}
+              </div>
+            )}
+            <Button type="submit" className="w-full" disabled={loading || !sessionReady}>
+              {loading ? "Updating..." : "Update password"}
+            </Button>
+          </form>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/auth/reset/page.tsx
+++ b/frontend/app/auth/reset/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { apiClient } from "@/lib/apiClient";
+import { Card } from "@/components/ui/Card";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
+
+export default function ResetRequestPage() {
+  const [email, setEmail] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      await apiClient.post("/api/auth/password-reset/request", { email });
+      setSubmitted(true);
+    } catch {
+      setError("Unable to send reset email right now. Please try again shortly.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-12">
+      <Card>
+        <h1 className="text-3xl font-bold text-slate-50 mb-6 text-center">Reset your password</h1>
+        {submitted ? (
+          <div className="space-y-4 text-slate-200 text-center">
+            <p>Check your email for a link to reset your password.</p>
+            <p className="text-sm text-slate-400">
+              If you don&apos;t see it in a few minutes, check your spam folder or try again.
+            </p>
+            <Link href="/auth/login" className="text-emerald-400 hover:underline">
+              Back to login
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="email"
+              label="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={loading}
+            />
+            {error && (
+              <div className="p-3 bg-red-900/50 border border-red-700 rounded-lg text-red-300 text-sm">
+                {error}
+              </div>
+            )}
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Sending..." : "Send reset link"}
+            </Button>
+            <p className="text-center text-sm text-slate-400">
+              Remembered your password?{" "}
+              <Link href="/auth/login" className="text-emerald-400 hover:underline">
+                Go back to login
+              </Link>
+            </p>
+          </form>
+        )}
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add backend endpoints to request password reset via Supabase and confirm with token (rate-limited)
- new frontend pages `/auth/reset` and `/auth/reset/confirm` to request links and set new passwords
- add forgot-password link from login

## Testing
- frontend: npm run lint