### PR TITLE
fix: allow invitees to load table with invite code

### DIFF
--- a/backend/src/api/tables.controller.ts
+++ b/backend/src/api/tables.controller.ts
@@ -186,4 +186,73 @@ export async function registerTableRoutes(app: FastifyInstance) {
       });
     }
   );
-*** End Patch
+
+  // Sit down
+  app.post(
+    "/:id/sit-down",
+    { preHandler: authenticate },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const req = request as AuthenticatedRequest;
+      const userId = req.userId;
+      const params = request.params as { id: string };
+      const body = sitDownSchema.parse(request.body);
+
+      try {
+        const result = await sitDown(params.id, userId, body.seatIndex, body.buyInAmount);
+
+        return reply.send({
+          tableId: result.tableId,
+          seatIndex: result.seatIndex,
+          userId: result.userId,
+          displayName: result.displayName,
+          stack: result.stack,
+          isSittingOut: result.isSittingOut,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "UNKNOWN_ERROR";
+        const statusCode =
+          errorMessage === "INVALID_SEAT" || errorMessage === "SEAT_TAKEN" || errorMessage === "INVALID_BUYIN"
+            ? 400
+            : 500;
+
+        return reply.status(statusCode).send({
+          error: {
+            code: errorMessage,
+            message: errorMessage,
+          },
+        });
+      }
+    }
+  );
+
+  // Stand up
+  app.post(
+    "/:id/stand-up",
+    { preHandler: authenticate },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const req = request as AuthenticatedRequest;
+      const userId = req.userId;
+      const params = request.params as { id: string };
+
+      try {
+        const result = await standUp(params.id, userId);
+
+        return reply.send({
+          tableId: result.tableId,
+          seatIndex: result.seatIndex,
+          remainingStack: result.remainingStack,
+        });
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "UNKNOWN_ERROR";
+        const statusCode = errorMessage === "NOT_SEATED" ? 400 : 500;
+
+        return reply.status(statusCode).send({
+          error: {
+            code: errorMessage,
+            message: errorMessage,
+          },
+        });
+      }
+    }
+  );
+}

--- a/backend/src/ws/schemas.ts
+++ b/backend/src/ws/schemas.ts
@@ -7,6 +7,7 @@ const uuid = () =>
 
 export const joinTableSchema = z.object({
   tableId: uuid(),
+  inviteCode: z.string().optional(),
 });
 
 export const leaveTableSchema = z.object({

--- a/backend/src/ws/table.handler.ts
+++ b/backend/src/ws/table.handler.ts
@@ -27,11 +27,12 @@ async function handleJoinTable(
       return;
     }
 
-    // Check if user is allowed (host or has a seat)
+    // Check if user is allowed (host or has a seat or holds valid invite)
     const isHost = table.hostUserId === userId;
     const hasSeat = table.seats.some((s) => s.userId === userId);
+    const hasValidInvite = msg.inviteCode && msg.inviteCode === table.inviteCode;
 
-    if (!isHost && !hasSeat) {
+    if (!isHost && !hasSeat && !hasValidInvite) {
       sendError(socket, "NOT_IN_TABLE", "You are not a member of this table.");
       return;
     }

--- a/frontend/app/lobby/page.tsx
+++ b/frontend/app/lobby/page.tsx
@@ -59,13 +59,14 @@ export default function LobbyPage() {
     }
 
     try {
+      const code = inviteCode.trim();
       const table = await apiClient.post<{ tableId: string; name: string; maxPlayers: number; status: string }>(
         "/api/tables/join-by-code",
-        { inviteCode: inviteCode.trim() }
+        { inviteCode: code }
       );
       setShowJoinModal(false);
       setInviteCode("");
-      router.push(`/table/${table.tableId}`);
+      router.push(`/table/${table.tableId}?inviteCode=${encodeURIComponent(code)}`);
     } catch (err) {
       setError(err instanceof ApiError ? err.message : "Failed to join table");
     }

--- a/frontend/app/table/[id]/page.tsx
+++ b/frontend/app/table/[id]/page.tsx
@@ -22,9 +22,9 @@ export default function TablePage() {
   const tableId = params.id as string;
   const inviteCode = searchParams.get("inviteCode");
   const { user, loading: authLoading } = useAuth();
-  const { tableState, handResult, clearHandResult, connected } = useTableState(tableId);
-  const { messages, sendMessage, connected: chatConnected } = useChat(tableId);
-  const { emit } = useWebSocket(tableId);
+  const { tableState, handResult, clearHandResult, connected } = useTableState(tableId, inviteCode);
+  const { messages, sendMessage, connected: chatConnected } = useChat(tableId, inviteCode);
+  const { emit } = useWebSocket(tableId, inviteCode);
   const [actionError, setActionError] = useState<string | null>(null);
 
   // Persist invite code so reloads/reconnects keep access

--- a/frontend/app/table/[id]/page.tsx
+++ b/frontend/app/table/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/hooks/useAuth";
 import { useTableState } from "@/hooks/useTableState";
@@ -18,16 +18,33 @@ import { HandResultOverlay } from "@/components/table/HandResultOverlay";
 export default function TablePage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const tableId = params.id as string;
+  const inviteCode = searchParams.get("inviteCode");
   const { user, loading: authLoading } = useAuth();
   const { tableState, handResult, clearHandResult, connected } = useTableState(tableId);
   const { messages, sendMessage, connected: chatConnected } = useChat(tableId);
   const { emit } = useWebSocket(tableId);
   const [actionError, setActionError] = useState<string | null>(null);
 
+  // Persist invite code so reloads/reconnects keep access
+  useEffect(() => {
+    if (inviteCode && tableId) {
+      localStorage.setItem(`tableInvite:${tableId}`, inviteCode);
+    }
+  }, [inviteCode, tableId]);
+
+  const storedInvite = typeof window !== "undefined" && tableId
+    ? localStorage.getItem(`tableInvite:${tableId}`)
+    : null;
+  const effectiveInvite = inviteCode || storedInvite || null;
+
   const { data: table, isLoading } = useQuery({
-    queryKey: ["table", tableId],
-    queryFn: () => apiClient.get<Table>(`/api/tables/${tableId}`),
+    queryKey: ["table", tableId, effectiveInvite],
+    queryFn: () =>
+      apiClient.get<Table>(
+        `/api/tables/${tableId}${effectiveInvite ? `?inviteCode=${encodeURIComponent(effectiveInvite)}` : ""}`
+      ),
     enabled: !!tableId && !!user,
   });
 
@@ -78,11 +95,6 @@ export default function TablePage() {
       amount,
     });
   };
-
-  const mySeat = useMemo(
-    () => tableState?.seats.find((s) => s.isSelf),
-    [tableState]
-  );
 
   if (authLoading || isLoading) {
     return (
@@ -142,11 +154,12 @@ export default function TablePage() {
         </div>
       )}
 
-      {mySeat && tableState.toActSeatIndex === mySeat.seatIndex && (
-        <div className="mt-4 text-center text-emerald-300 text-sm">
-          Your turn to act.
-        </div>
-      )}
+      {tableState.seats.find((s) => s.isSelf) &&
+        tableState.toActSeatIndex === tableState.seats.find((s) => s.isSelf)?.seatIndex && (
+          <div className="mt-4 text-center text-emerald-300 text-sm">
+            Your turn to act.
+          </div>
+        )}
     </div>
   );
 }

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -5,9 +5,9 @@ import type { ChatMessage } from "@/lib/types";
 import { useWebSocket } from "./useWebSocket";
 import { apiClient } from "@/lib/apiClient";
 
-export function useChat(tableId: string) {
+export function useChat(tableId: string, inviteCode?: string | null) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const { socket, connected, emit, on } = useWebSocket(tableId);
+  const { socket, connected, emit, on } = useWebSocket(tableId, inviteCode);
 
   // Load chat history on mount
   useEffect(() => {

--- a/frontend/hooks/useWebSocket.ts
+++ b/frontend/hooks/useWebSocket.ts
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Socket } from "socket.io-client";
 import { getSocket, disconnectSocket, refreshAndReconnect } from "@/lib/wsClient";
 
-export function useWebSocket(tableId?: string) {
+export function useWebSocket(tableId?: string, inviteCode?: string | null) {
   const [socket, setSocket] = useState<Socket | null>(null);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -20,7 +20,7 @@ export function useWebSocket(tableId?: string) {
         setConnected(true);
         setError(null);
         if (tableId) {
-          ws.emit("JOIN_TABLE", { tableId });
+          ws.emit("JOIN_TABLE", { tableId, inviteCode });
         }
       });
 
@@ -72,7 +72,7 @@ export function useWebSocket(tableId?: string) {
       }
       disconnectSocket();
     };
-  }, [tableId]);
+  }, [tableId, inviteCode]);
 
   const emit = useCallback(
     (event: string, data?: unknown) => {

--- a/frontend/lib/wsClient.ts
+++ b/frontend/lib/wsClient.ts
@@ -6,38 +6,49 @@ import { supabase } from "./supabaseClient";
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:4000";
 
 let socket: Socket | null = null;
+let currentToken: string | null = null;
 
-export async function getSocket(): Promise<Socket> {
-  if (socket && socket.connected) {
-    return socket;
-  }
-
+export async function getSocket(forceNew = false): Promise<Socket> {
   const {
     data: { session },
   } = await supabase.auth.getSession();
 
-  const token = session?.access_token;
+  const token = session?.access_token || null;
 
   if (!token) {
     throw new Error("No authentication token available");
   }
 
-  socket = io(WS_URL, {
-    auth: { token },
-    transports: ["websocket"],
-    reconnection: true,
-    reconnectionDelay: 1000,
-    reconnectionAttempts: 5,
-  });
+  const tokenChanged = token !== currentToken;
+  const needsNew = forceNew || tokenChanged || !socket || !socket.connected;
 
-  return socket;
+  if (needsNew) {
+    // tear down previous socket before creating a new one
+    if (socket) {
+      socket.disconnect();
+    }
+    socket = io(WS_URL, {
+      auth: { token },
+      transports: ["websocket"],
+      reconnection: true,
+      reconnectionDelay: 1000,
+      reconnectionAttempts: 5,
+    });
+    currentToken = token;
+  }
+
+  return socket!;
+}
+
+export async function refreshAndReconnect(): Promise<Socket> {
+  await supabase.auth.refreshSession();
+  return getSocket(true);
 }
 
 export function disconnectSocket() {
   if (socket) {
     socket.disconnect();
     socket = null;
+    currentToken = null;
   }
 }
-
-


### PR DESCRIPTION
## Summary
- Backend: allow authenticated requests to `GET /api/tables/:id` when a valid inviteCode query param matches the table invite code (still restricts others)
- Frontend: propagate inviteCode from lobby join modal to table URL, and include inviteCode when fetching table details on /table/[id]

## Testing
- frontend: npm run lint