### PR TITLE
feat: host can start game when table has players

### DIFF
--- a/backend/src/services/table.service.ts
+++ b/backend/src/services/table.service.ts
@@ -243,6 +243,9 @@ export async function sitDown(
     },
   });
 
+  // Seating changes must invalidate cached engine state so fresh seats are used
+  await deleteTableStateFromRedis(tableId);
+
   return {
     tableId,
     seatIndex,
@@ -274,6 +277,8 @@ export async function standUp(tableId: string, userId: string) {
       stack: 0,
     },
   });
+
+  await deleteTableStateFromRedis(tableId);
 
   return {
     tableId,

--- a/docs/features/gameplay-texas-holdem.md
+++ b/docs/features/gameplay-texas-holdem.md
@@ -9,6 +9,13 @@ This document defines the **strict TypeScript contract** for the **Texas Hold'em
 
 Agents implementing the engine **must** conform to these interfaces and invariants.
 
+### Host-driven game start (UI)
+
+- The table does not auto-start when only two players are present; the host can manually trigger the first hand.
+- When the host is seated with chips, at least one other non-sitting-out player is seated with chips, and no hand is active, the host sees a red **Start** button on their seat card (replaces the "Sit Here" CTA slot).
+- Clicking **Start** emits `GAME_START`; the button disables while the request is in-flight and re-enables once the next `TABLE_STATE` arrives or an error is returned over the `ERROR` channel.
+- If conditions drop below two ready players or a hand is running, the Start button disappears.
+
 ---
 
 ## 1. Design Goals
@@ -469,4 +476,3 @@ See `/docs/testing/engine-test-plan.md` for detailed scenarios.
 
 This spec is the **source of truth** for engine behavior.
 The frontend, WebSocket protocol, and REST API layers must all align with these models and invariants.
-

--- a/frontend/components/table/PlayerSeat.tsx
+++ b/frontend/components/table/PlayerSeat.tsx
@@ -10,6 +10,11 @@ interface PlayerSeatProps {
   isVacant: boolean;
   canSelectSeat?: boolean;
   onSelectSeat?: (seatIndex: number) => void;
+  startControl?: {
+    pending: boolean;
+    error?: string | null;
+    onStart: () => void;
+  };
 }
 
 export function PlayerSeat({
@@ -20,6 +25,7 @@ export function PlayerSeat({
   isVacant,
   canSelectSeat,
   onSelectSeat,
+  startControl,
 }: PlayerSeatProps) {
   // Calculate position around the table (circular layout)
   const angle = (position / totalSeats) * 2 * Math.PI - Math.PI / 2;
@@ -66,6 +72,21 @@ export function PlayerSeat({
           >
             Sit Here
           </button>
+        )}
+        {startControl && (
+          <div className="mt-2">
+            <button
+              className="w-full rounded-md border border-red-500 bg-red-900/70 px-2 py-1 text-xs font-semibold text-red-100 hover:bg-red-800 disabled:opacity-60 disabled:cursor-not-allowed"
+              onClick={startControl.onStart}
+              type="button"
+              disabled={startControl.pending}
+            >
+              {startControl.pending ? "Starting..." : "Start"}
+            </button>
+            {startControl.error && (
+              <p className="mt-1 text-xs text-red-200">{startControl.error}</p>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/frontend/components/table/PokerTable.tsx
+++ b/frontend/components/table/PokerTable.tsx
@@ -6,14 +6,28 @@ import { CommunityCards } from "./CommunityCards";
 import { PotDisplay } from "./PotDisplay";
 import type { PublicTableView, Table } from "@/lib/types";
 
+interface StartControl {
+  seatIndex: number;
+  pending: boolean;
+  error?: string | null;
+  onStart: () => void;
+}
+
 interface PokerTableProps {
   tableState: PublicTableView;
   tableMeta: Table;
   canSelectSeat?: boolean;
   onSeatSelect?: (seatIndex: number) => void;
+  startControl?: StartControl | null;
 }
 
-export function PokerTable({ tableState, tableMeta, canSelectSeat = false, onSeatSelect }: PokerTableProps) {
+export function PokerTable({
+  tableState,
+  tableMeta,
+  canSelectSeat = false,
+  onSeatSelect,
+  startControl,
+}: PokerTableProps) {
   const occupancy = useMemo(() => {
     const map = new Map<number, boolean>();
     (tableMeta.seats || []).forEach((seat) => {
@@ -36,6 +50,10 @@ export function PokerTable({ tableState, tableMeta, canSelectSeat = false, onSea
         <div className="absolute inset-0">
           {tableState.seats.map((seat) => {
             const isVacant = !(occupancy.get(seat.seatIndex) ?? true);
+            const seatStartControl =
+              startControl && startControl.seatIndex === seat.seatIndex
+                ? startControl
+                : undefined;
             return (
               <PlayerSeat
                 key={seat.seatIndex}
@@ -46,6 +64,7 @@ export function PokerTable({ tableState, tableMeta, canSelectSeat = false, onSea
                 isVacant={isVacant}
                 canSelectSeat={canSelectSeat}
                 onSelectSeat={onSeatSelect}
+                startControl={seatStartControl}
               />
             );
           })}

--- a/frontend/hooks/useTableState.ts
+++ b/frontend/hooks/useTableState.ts
@@ -78,5 +78,13 @@ export function useTableState(tableId: string, inviteCode?: string | null) {
     }
   }, [connected, emit, tableId]);
 
-  return { tableState, handResult, clearHandResult: () => setHandResult(null), connected, startGame };
+  return {
+    tableState,
+    handResult,
+    clearHandResult: () => setHandResult(null),
+    connected,
+    startGame,
+    emit,
+    on,
+  };
 }


### PR DESCRIPTION
## Summary
- add a host-only Start control on the host's seat when at least two seated players are ready and no hand is running
- wire the button to GAME_START with pending/inline error feedback and reuse the shared websocket hook for actions
- document the host-driven start flow in gameplay notes

## Testing
- cd frontend && npm run lint

Resolves #37.