### PR TITLE
Fix rejoin leaving host sitting out

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -23,6 +23,13 @@ npm run prisma:migrate
 npm run seed
 ```
 
+4. Seed Supabase-authenticated test users (auto-confirms email, also seeds table + seats):
+```bash
+npm run seed:test-users
+```
+
+> Requires `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_URL`, `SUPABASE_JWT_SECRET`, and `DATABASE_URL` to be set. No confirmation emails are sent; users are created in a verified state for automated tests.
+
 4. Start the server:
 ```bash
 npm run dev

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "prisma:generate": "prisma generate",
     "prisma:studio": "prisma studio",
     "seed": "ts-node scripts/seed.ts",
+    "seed:test-users": "ts-node scripts/seed-test-users.ts",
     "test": "vitest --watch=false",
     "test:integration": "playwright test tests/integration",
     "test:ws": "playwright test tests/websocket",

--- a/backend/scripts/seed-test-users.ts
+++ b/backend/scripts/seed-test-users.ts
@@ -1,0 +1,184 @@
+import "dotenv/config";
+import { randomUUID } from "crypto";
+import jwt from "jsonwebtoken";
+import { PrismaClient } from "@prisma/client";
+import { User, createClient } from "@supabase/supabase-js";
+
+// Minimal, self-contained script to seed Supabase auth users + Prisma profiles for automated tests.
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "";
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+const SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET || "";
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required to seed test users.");
+}
+
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+const prisma = new PrismaClient();
+
+type SeedUser = {
+  email: string;
+  password: string;
+  displayName: string;
+};
+
+const TEST_USERS: SeedUser[] = [
+  {
+    email: "alice.test@example.com",
+    password: "Password123!",
+    displayName: "Alice Test",
+  },
+  {
+    email: "bob.test@example.com",
+    password: "Password123!",
+    displayName: "Bob Test",
+  },
+];
+
+const TEST_TABLE = {
+  inviteCode: "TEST123",
+  name: "Automated Test Table",
+  maxPlayers: 6,
+  smallBlind: 5,
+  bigBlind: 10,
+  status: "OPEN" as const,
+};
+
+async function findAuthUserByEmail(email: string): Promise<User | null> {
+  const { data, error } = await supabaseAdmin.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  if (error || !data) {
+    throw new Error(`Failed to list Supabase users: ${error?.message}`);
+  }
+  return data.users.find((user) => user.email?.toLowerCase() === email.toLowerCase()) ?? null;
+}
+
+async function ensureAuthUser(user: SeedUser): Promise<User> {
+  const existing = await findAuthUserByEmail(user.email);
+
+  if (existing) {
+    const { data, error } = await supabaseAdmin.auth.admin.updateUserById(existing.id, {
+      password: user.password,
+      email_confirm: true,
+      user_metadata: { displayName: user.displayName },
+    });
+    if (error || !data.user) {
+      throw new Error(`Failed to update existing Supabase user ${user.email}: ${error?.message}`);
+    }
+    return data.user;
+  }
+
+  const { data, error } = await supabaseAdmin.auth.admin.createUser({
+    email: user.email,
+    password: user.password,
+    email_confirm: true,
+    user_metadata: { displayName: user.displayName },
+  });
+  if (error || !data.user) {
+    throw new Error(`Failed to create Supabase user ${user.email}: ${error?.message}`);
+  }
+  return data.user;
+}
+
+async function ensureProfile(userId: string, displayName: string) {
+  await prisma.profile.upsert({
+    where: { id: userId },
+    update: { displayName },
+    create: { id: userId, displayName },
+  });
+}
+
+async function upsertTestTable(hostUserId: string, guestUserId: string) {
+  const table = await prisma.table.upsert({
+    where: { inviteCode: TEST_TABLE.inviteCode },
+    update: {
+      hostUserId,
+      name: TEST_TABLE.name,
+      maxPlayers: TEST_TABLE.maxPlayers,
+      smallBlind: TEST_TABLE.smallBlind,
+      bigBlind: TEST_TABLE.bigBlind,
+      status: TEST_TABLE.status,
+    },
+    create: {
+      id: randomUUID(),
+      inviteCode: TEST_TABLE.inviteCode,
+      hostUserId,
+      name: TEST_TABLE.name,
+      maxPlayers: TEST_TABLE.maxPlayers,
+      smallBlind: TEST_TABLE.smallBlind,
+      bigBlind: TEST_TABLE.bigBlind,
+      status: TEST_TABLE.status,
+    },
+  });
+
+  const seats = [
+    { seatIndex: 0, userId: hostUserId },
+    { seatIndex: 1, userId: guestUserId },
+  ];
+
+  for (const seat of seats) {
+    await prisma.seat.upsert({
+      where: { tableId_seatIndex: { tableId: table.id, seatIndex: seat.seatIndex } },
+      update: { userId: seat.userId, stack: 1000, isSittingOut: false },
+      create: {
+        tableId: table.id,
+        seatIndex: seat.seatIndex,
+        userId: seat.userId,
+        stack: 1000,
+        isSittingOut: false,
+      },
+    });
+  }
+
+  return table;
+}
+
+function buildTestToken(userId: string, email: string) {
+  if (!SUPABASE_JWT_SECRET) return null;
+
+  return jwt.sign(
+    {
+      sub: userId,
+      email,
+      role: "authenticated",
+      aud: "authenticated",
+    },
+    SUPABASE_JWT_SECRET,
+    { algorithm: "HS256", expiresIn: "7d" }
+  );
+}
+
+async function main() {
+  console.log("Seeding Supabase auth users and Prisma profiles for tests...");
+
+  const seededUsers = [] as Array<SeedUser & { id: string; token: string | null }>;
+
+  for (const user of TEST_USERS) {
+    const authUser = await ensureAuthUser(user);
+    await ensureProfile(authUser.id, user.displayName);
+
+    seededUsers.push({ ...user, id: authUser.id, token: buildTestToken(authUser.id, user.email) });
+  }
+
+  const table = await upsertTestTable(seededUsers[0].id, seededUsers[1].id);
+
+  console.log("Seed complete. Use the following credentials in automated tests:");
+  for (const user of seededUsers) {
+    console.log(`- ${user.displayName} <${user.email}> (id: ${user.id})`);
+    console.log(`  password: ${user.password}`);
+    if (user.token) console.log(`  jwt: ${user.token}`);
+  }
+  console.log(`- Test table: ${TEST_TABLE.name} (invite code: ${TEST_TABLE.inviteCode}, id: ${table.id})`);
+}
+
+main()
+  .catch((err) => {
+    console.error("Seed failed:", err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/services/table.service.ts
+++ b/backend/src/services/table.service.ts
@@ -301,6 +301,16 @@ export async function standUp(tableId: string, userId: string) {
   };
 }
 
+// Reactivate a seated player when they reconnect (clear sitting out flag)
+export async function activateSeat(tableId: string, userId: string): Promise<boolean> {
+  const result = await prisma.seat.updateMany({
+    where: { tableId, userId, isSittingOut: true },
+    data: { isSittingOut: false },
+  });
+
+  return result.count > 0;
+}
+
 function formatTableWithSeats(table: any): TableWithSeats {
   return {
     id: table.id,

--- a/backend/tests/unit/table.handler.test.ts
+++ b/backend/tests/unit/table.handler.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Server, Socket } from "socket.io";
+
+vi.mock("../../src/services/table.service", () => {
+  return {
+    getTableById: vi.fn(),
+    activateSeat: vi.fn(),
+    deleteTableStateFromRedis: vi.fn(),
+    sitDown: vi.fn(),
+    standUp: vi.fn(),
+  };
+});
+
+vi.mock("../../src/services/game.service", () => {
+  return {
+    getPublicTableView: vi.fn(),
+    ensureTableState: vi.fn(),
+    applyPlayerAction: vi.fn(),
+  };
+});
+
+import { tableHandlers } from "../../src/ws/table.handler";
+import * as tableService from "../../src/services/table.service";
+import * as gameService from "../../src/services/game.service";
+
+describe("handleJoinTable", () => {
+  const joinTable = tableHandlers.handleJoinTable;
+
+  const mockSocket = () => {
+    return {
+      join: vi.fn(),
+      emit: vi.fn(),
+    } as unknown as Socket;
+  };
+
+  const mockIo = () => ({
+    in: vi.fn().mockReturnValue({ fetchSockets: vi.fn().mockResolvedValue([]) }),
+  }) as unknown as Server;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("reactivates a sitting-out seat on reconnect and refreshes state", async () => {
+    const socket = mockSocket();
+    const io = mockIo();
+
+    (tableService.getTableById as vi.Mock).mockResolvedValue({
+      id: "table-1",
+      hostUserId: "user-1",
+      inviteCode: "TEST123",
+      seats: [
+        { seatIndex: 0, userId: "user-1", isSittingOut: true, stack: 1000 },
+        { seatIndex: 1, userId: "user-2", isSittingOut: false, stack: 1000 },
+      ],
+    });
+
+    (tableService.activateSeat as vi.Mock).mockResolvedValue(true);
+    (tableService.deleteTableStateFromRedis as vi.Mock).mockResolvedValue(undefined);
+    (gameService.ensureTableState as vi.Mock).mockResolvedValue(undefined);
+    (gameService.getPublicTableView as vi.Mock).mockResolvedValue({ tableId: "table-1", seats: [] });
+
+    await joinTable(io, socket, { tableId: "table-1", inviteCode: "TEST123" }, "user-1");
+
+    expect(tableService.activateSeat).toHaveBeenCalledWith("table-1", "user-1");
+    expect(tableService.deleteTableStateFromRedis).toHaveBeenCalledWith("table-1");
+    expect(gameService.ensureTableState).toHaveBeenCalledWith("table-1");
+    // TABLE_STATE should be emitted to the reconnecting user
+    expect(socket.emit).toHaveBeenCalledWith(
+      "TABLE_STATE",
+      expect.objectContaining({ tableId: "table-1" })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- reactivate seated players on reconnect by clearing `isSittingOut` and refreshing table state
- add Supabase auth test seed script and npm alias to create verified test users
- add unit test for JOIN_TABLE reactivation path

## Testing
- npm run seed:test-users
- cd backend && npm test -- table.handler