### PR TITLE
Display self hole cards at the table

### DIFF
--- a/frontend/components/table/PlayerSeat.tsx
+++ b/frontend/components/table/PlayerSeat.tsx
@@ -22,6 +22,7 @@ interface PlayerSeatProps {
     error?: string | null;
     onStand: () => void;
   };
+  holeCards?: string[];
 }
 
 export function PlayerSeat({
@@ -34,6 +35,7 @@ export function PlayerSeat({
   onSelectSeat,
   startControl,
   standControl,
+  holeCards,
 }: PlayerSeatProps) {
   // Calculate position around the table (circular layout)
   const angle = (position / totalSeats) * 2 * Math.PI - Math.PI / 2;
@@ -71,6 +73,18 @@ export function PlayerSeat({
         )}
         {seat.isSelf && seat.status === "ACTIVE" && (
           <div className="text-xs text-emerald-200">You</div>
+        )}
+        {holeCards && holeCards.length > 0 && seat.isSelf && (
+          <div className="mt-2 flex gap-1">
+            {holeCards.map((card, idx) => (
+              <div
+                key={idx}
+                className="w-10 h-14 bg-white text-slate-900 font-semibold text-sm rounded-md border border-slate-300 shadow"
+              >
+                <div className="flex items-center justify-center h-full">{card}</div>
+              </div>
+            ))}
+          </div>
         )}
         {isVacant && canSelectSeat && !seat.isSelf && (
           <button

--- a/frontend/components/table/PokerTable.tsx
+++ b/frontend/components/table/PokerTable.tsx
@@ -50,27 +50,29 @@ export function PokerTable({ tableState, tableMeta, canSelectSeat = false, onSea
         <div className="absolute inset-0">
           {tableState.seats.map((seat) => {
             const isVacant = !(occupancy.get(seat.seatIndex) ?? true);
-            const seatStartControl =
-              startControl && startControl.seatIndex === seat.seatIndex ? startControl : undefined;
-            const seatStandControl =
-              standControl && standControl.seatIndex === seat.seatIndex ? standControl : undefined;
-            return (
-              <PlayerSeat
-                key={seat.seatIndex}
-                seat={seat}
-                position={seat.seatIndex}
-                totalSeats={tableMeta.maxPlayers}
-                isActive={tableState.toActSeatIndex === seat.seatIndex}
-                isVacant={isVacant}
-                canSelectSeat={canSelectSeat}
-                onSelectSeat={onSeatSelect}
-                startControl={seatStartControl}
-                standControl={seatStandControl}
-              />
-            );
-          })}
-        </div>
+          const seatStartControl =
+            startControl && startControl.seatIndex === seat.seatIndex ? startControl : undefined;
+          const seatStandControl =
+            standControl && standControl.seatIndex === seat.seatIndex ? standControl : undefined;
+          const selfHoleCards = seat.isSelf ? tableState.holeCards : undefined;
+          return (
+            <PlayerSeat
+              key={seat.seatIndex}
+              seat={seat}
+              position={seat.seatIndex}
+              totalSeats={tableMeta.maxPlayers}
+              isActive={tableState.toActSeatIndex === seat.seatIndex}
+              isVacant={isVacant}
+              canSelectSeat={canSelectSeat}
+              onSelectSeat={onSeatSelect}
+              startControl={seatStartControl}
+              standControl={seatStandControl}
+              holeCards={selfHoleCards}
+            />
+          );
+        })}
       </div>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- pass `holeCards` from table state to the self seat in `PokerTable`
- render hole cards alongside the self seat so players can see their hand

## Testing
- cd frontend && npm run lint -- --max-warnings=0
- manual: host seat now shows your two cards while community cards remain shared