### PR TITLE
Docs: prefer managed Redis for REDIS_URL

### DIFF
--- a/docs/setup/backend-setup.md
+++ b/docs/setup/backend-setup.md
@@ -152,6 +152,10 @@ SUPABASE_JWT_SECRET=<supabase-jwt-secret>
 DATABASE_URL=postgresql://postgres:<password>@db.<domain>.supabase.co:5432/postgres
 
 # Redis
+# Prefer managed Redis in staging/production; keep localhost for local dev.
+# Examples:
+#  - Local:   redis://localhost:6379
+#  - Managed: rediss://:<password>@<host>:<port>
 REDIS_URL=redis://localhost:6379
 
 # Backend

--- a/docs/setup/environment-setup.md
+++ b/docs/setup/environment-setup.md
@@ -79,6 +79,11 @@ DATABASE_URL="postgresql://postgres:<pass>@db.<domain>.supabase.co:5432/postgres
 SUPABASE_JWT_SECRET=<your-supabase-jwt-secret>
 
 # Redis connection
+# Use managed Redis in non-local environments; fallback to localhost for local dev.
+# Examples:
+#   - Local dev:          REDIS_URL="redis://localhost:6379"
+#   - Managed (Upstash):  REDIS_URL="rediss://:<password>@<host>:<port>"
+#   - Managed (Elastic):  REDIS_URL="rediss://:<user>:<password>@<host>:<port>"
 REDIS_URL="redis://localhost:6379"
 
 # Backend


### PR DESCRIPTION
## Summary
- Document using managed Redis for non-local environments while keeping localhost for dev.
- Add REDIS_URL examples (Upstash/Elastic-style rediss URLs) in env setup and backend setup docs.

## Testing
- Documentation-only change.