### PR TITLE
Worker: monitoring and graceful shutdown (stacked on queue refactor)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -53,6 +53,7 @@ npm run dev
 - **Database**: Supabase Postgres via Prisma ORM
 - **Cache**: Redis for table state and pub/sub
 - **Game Engine**: Pure TypeScript module for poker logic
+- **Worker**: Dedicated BullMQ worker (`src/worker.ts`) consumes game queues; run separately from the API/WS process.
 
 ## API Endpoints
 

--- a/backend/src/queue/monitor.ts
+++ b/backend/src/queue/monitor.ts
@@ -1,0 +1,41 @@
+import { Queue, QueueEvents } from "bullmq";
+import { logger } from "../config/logger";
+
+export interface QueueMonitorOptions {
+  intervalMs?: number;
+}
+
+export function startQueueMonitoring(queues: Queue[], options: QueueMonitorOptions = {}) {
+  const intervalMs = options.intervalMs ?? 30000;
+
+  for (const q of queues) {
+    const events = new QueueEvents(q.name, { connection: q.opts.connection });
+
+    events.on("stalled", ({ jobId }) => {
+      logger.warn(`Queue ${q.name} stalled job ${jobId}`);
+    });
+
+    events.on("failed", ({ jobId, failedReason }) => {
+      logger.error(`Queue ${q.name} job ${jobId} failed: ${failedReason}`);
+    });
+
+    events.on("waiting", ({ jobId }) => {
+      logger.debug(`Queue ${q.name} waiting job ${jobId}`);
+    });
+  }
+
+  const timer = setInterval(async () => {
+    for (const q of queues) {
+      try {
+        const counts = await q.getJobCounts("waiting", "active", "delayed", "failed");
+        logger.info(
+          `Queue ${q.name} counts waiting=${counts.waiting} active=${counts.active} delayed=${counts.delayed} failed=${counts.failed}`
+        );
+      } catch (err) {
+        logger.error(`Failed to collect metrics for ${q.name}`, err);
+      }
+    }
+  }, intervalMs);
+
+  timer.unref();
+}


### PR DESCRIPTION
## Summary
- add queue monitoring helper (QueueEvents + periodic job counts) for actions/turn-timers/auto-start queues
- add monitoring to worker startup and log stalled/failed jobs
- add graceful shutdown handlers (SIGINT/SIGTERM) to close workers cleanly
- document dedicated worker role in backend README

## Testing
- npm run build
- npm test

## Note
- This PR is stacked on #55 (feature/52-bullmq-queue). Merge #55 first, then this.
