### PR TITLE
Add Render deployment blueprint for production hosting

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,157 @@
+# Deployment Guide
+
+This guide covers deploying the Texas Hold'em Poker App using **Render for the backend** and **Vercel for the frontend**.
+
+## Architecture Overview
+
+- **Backend (Render)**: Node.js API + WebSocket server + Redis
+- **Frontend (Vercel)**: Next.js static site
+- **Database**: Supabase (PostgreSQL)
+- **Cache**: Render Managed Redis
+
+---
+
+## Prerequisites
+
+1. [Render](https://render.com) account
+2. [Vercel](https://vercel.com) account
+3. [Supabase](https://supabase.com) project (for database + auth)
+4. Code pushed to GitHub
+
+---
+
+## Deployment Steps (Two-Step Process)
+
+### Step 1: Deploy Backend to Render
+
+This must be done first to get the backend URL.
+
+1. Go to [Render Dashboard](https://dashboard.render.com)
+2. Click **"New +"** → **"Blueprint"**
+3. Connect your GitHub repository
+4. Select the repository and branch
+5. Render will read `render.yaml` and create:
+   - `poker-backend` (Node.js WebSocket server) - **$7/mo starter plan**
+   - `poker-redis` (Managed Redis) - **Free tier**
+
+6. **Set required environment variables** in Render Dashboard:
+   - `DATABASE_URL` - Your Supabase PostgreSQL connection string
+   - `SUPABASE_URL` - Your Supabase project URL
+   - `SUPABASE_SERVICE_ROLE_KEY` - From Supabase Project Settings > API
+   - `SUPABASE_JWT_SECRET` - From Supabase Project Settings > API > JWT Settings
+
+7. Wait for deployment to complete (check logs for `Server running on port X`)
+
+8. **Copy your backend URL**: `https://poker-backend-xxx.onrender.com`
+
+---
+
+### Step 2: Set FRONTEND_URL Environment Variable in Render
+
+After you get your Vercel URL (in Step 3), come back and set this:
+
+1. In Render Dashboard, go to `poker-backend` service
+2. Navigate to **Environment** tab
+3. Add environment variable:
+   - `FRONTEND_URL` = `https://your-app.vercel.app` (from Step 3)
+4. The service will auto-redeploy
+
+---
+
+### Step 3: Deploy Frontend to Vercel
+
+1. Go to [Vercel Dashboard](https://vercel.com)
+2. Click **"Add New Project"**
+3. Import your GitHub repository
+4. Configure project:
+   - **Framework Preset**: Next.js
+   - **Root Directory**: `frontend` (or leave blank if repo is just the frontend)
+   - **Build Command**: `npm run build`
+   - **Output Directory**: `dist`
+
+5. **Set environment variables**:
+   - `NEXT_PUBLIC_API_BASE_URL` = `https://poker-backend-xxx.onrender.com` (from Step 1)
+   - `NEXT_PUBLIC_WS_URL` = `wss://poker-backend-xxx.onrender.com`
+   - `NEXT_PUBLIC_SUPABASE_URL` = Your Supabase project URL
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY` = Your Supabase anon/public key
+
+6. Click **Deploy**
+
+7. **Copy your Vercel URL**: `https://your-app.vercel.app`
+
+---
+
+### Step 4: Complete the Loop
+
+1. Return to Render Dashboard (Step 2)
+2. Set `FRONTEND_URL` to your Vercel URL
+3. This enables CORS properly
+
+---
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `render.yaml` | Render Blueprint (backend + Redis only) |
+| `vercel.json` | Vercel build configuration |
+| `frontend/.env.production` | Template for Vercel env vars |
+| `DEPLOY.md` | This file |
+
+---
+
+## WebSocket Configuration
+
+WebSockets work on Render's Node.js services without special configuration. The backend:
+
+- Uses the same port for HTTP and WebSocket (Render requirement)
+- Automatically upgrades connections at `/ws/*` paths
+- Handles CORS based on `FRONTEND_URL` env var
+
+---
+
+## Troubleshooting
+
+### WebSocket Connection Fails
+- Verify `WS_URL` matches your Render backend URL (with `wss://`)
+- Check that `FRONTEND_URL` is set correctly in Render
+- Ensure no firewall/VPN blocking WebSocket connections
+
+### CORS Errors
+- Make sure `FRONTEND_URL` in Render matches your actual Vercel URL exactly
+- Check for trailing slashes (should not have them)
+
+### Redis Connection Issues
+- Redis URL is auto-populated from the Render Redis service
+- Verify the `poker-redis` service is created and running
+
+### Build Fails on Vercel
+- Check that `vercel.json` is in the repository root
+- Verify `dist` folder is created during build
+- Ensure all `NEXT_PUBLIC_` env vars are set before build
+
+---
+
+## Cost Overview
+
+| Service | Plan | Monthly Cost |
+|---------|------|--------------|
+| Render Backend | Starter (always-on) | ~$7 |
+| Render Redis | Starter (free tier) | $0 |
+| Vercel Frontend | Hobby | $0 |
+| Supabase | Free tier | $0 |
+
+**Total: ~$7/month** for the always-on backend + free frontend, Redis, and database.
+
+---
+
+## Post-Deployment Checklist
+
+- [ ] Backend deployed on Render with health check passing
+- [ ] Redis service created and connected
+- [ ] `FRONTEND_URL` set in Render environment
+- [ ] Frontend deployed on Vercel
+- [ ] Environment variables set in Vercel
+- [ ] WebSocket connection test successful
+- [ ] Game room creation works
+- [ ] User authentication via Supabase works

--- a/render.yaml
+++ b/render.yaml
@@ -58,7 +58,7 @@ services:
       - key: NEXT_PUBLIC_SUPABASE_URL
         sync: false
       - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
-        sync: false
+    publish: frontend/.next
       - key: NEXT_PUBLIC_API_BASE_URL
         value: https://poker-backend.onrender.com
       - key: NODE_ENV

--- a/render.yaml
+++ b/render.yaml
@@ -46,7 +46,7 @@ services:
     env: node
     plan: starter  # Hobby plan ($7/mo minimum for always-on)
     
-  # Frontend Static Site (Next.js)
+    
   - type: static
     name: poker-frontend
     runtime: static

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,76 @@
+# Render Blueprint for Texas Hold'em Poker App
+# Deploy to Render: https://render.com/docs/blueprint-spec
+
+services:
+  # Backend API + WebSocket Server
+  - type: web
+    name: poker-backend
+    runtime: node
+    repo: https://github.com/rmeyer1/demo
+    branch: main
+    buildCommand: cd backend && npm install && npm run build && npx prisma migrate deploy
+    startCommand: cd backend && npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        fromService:
+          type: web
+          name: poker-backend
+          envVarKey: PORT
+      # Production Database (Supabase recommended)
+      - key: DATABASE_URL
+        sync: false  # Set in Render dashboard
+      # Redis for session/cache
+      - key: REDIS_URL
+        sync: false  # Set in Render dashboard or use Render Redis
+      # Supabase Config
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: SUPABASE_JWT_SECRET
+        sync: false
+      # Frontend URLs for CORS
+      - key: FRONTEND_URL
+        value: https://poker-frontend.onrender.com
+      # API Config
+      - key: API_BASE_URL
+        value: https://poker-backend.onrender.com
+      - key: WS_URL
+        value: wss://poker-backend.onrender.com
+      - key: JWT_AUDIENCE
+        value: authenticated
+    healthCheckPath: /health
+    # WebSocket support
+    env: node
+    plan: starter  # Hobby plan ($7/mo minimum for always-on)
+    
+  # Frontend Static Site (Next.js)
+  - type: static
+    name: poker-frontend
+    runtime: static
+    repo: https://github.com/rmeyer1/demo
+    branch: main
+    buildCommand: cd frontend && npm install && npm run build
+    publish: frontend/dist
+    envVars:
+      - key: NEXT_PUBLIC_SUPABASE_URL
+        sync: false
+      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
+        sync: false
+      - key: NEXT_PUBLIC_API_BASE_URL
+        value: https://poker-backend.onrender.com
+      - key: NODE_ENV
+        value: production
+    headers:
+      - path: /*
+        name: Cache-Control
+        value: public, max-age=0, must-revalidate
+    
+  # Redis Cache (Render Managed Redis)
+  - type: redis
+    name: poker-redis
+    ipAllowList: []  # Allow all (required for Render services)
+    plan: starter  # Free tier available
+    maxmemoryPolicy: allkeys-lru

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm install",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
Adds Render deployment configuration to host the Texas Hold'em poker app on Render.com.

## What's Included

### Services Configured
1. **Backend API Service** (`poker-backend`)
   - Fastify + WebSocket support for real-time gameplay
   - Health check on `/health` endpoint
   - Prisma migrations run on deploy
   - Always-on hobby plan

2. **Frontend Static Site** (`poker-frontend`)
   - Next.js build output served as static files
   - CDN caching headers configured
   - Separate from backend for scaling

3. **Redis Cache** (`poker-redis`)
   - Render managed Redis instance
   - Free tier available
   - Allkeys-lru eviction policy

## Security - No Secrets in Repo

All sensitive environment variables use `sync: false`:
- `DATABASE_URL` - Supabase connection
- `SUPABASE_SERVICE_ROLE_KEY` - Supabase auth
- `SUPABASE_JWT_SECRET` - JWT signing
- `REDIS_URL` - Redis connection

These must be set in the Render dashboard after deployment.

## Post-Deploy Setup
1. Deploy using this blueprint
2. Create Redis instance
3. Copy values from local `.env.production` template to Render environment variables
4. Redeploy to pick up env vars
5. Test endpoints

## Related
- PR #70: User registration and public table listing APIs
- Production ready once this is deployed and env vars are configured