### PR TITLE
Fix render.yaml validation errors for Render deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -24,7 +24,7 @@ services:
         sync: false  # Set in Render dashboard
       - key: REDIS_URL
         sync: false
-      # Supabase Config
+        sync: false  # Set in Render dashboard or use Render Redis
       - key: SUPABASE_URL
         sync: false
       - key: SUPABASE_SERVICE_ROLE_KEY

--- a/render.yaml
+++ b/render.yaml
@@ -45,7 +45,7 @@ services:
     plan: starter
 
   # Redis Cache (Render Managed Redis)
-  - type: redis
+    ipAllowList: []  # Allow all (required for Render services)
     name: poker-redis
     ipAllowList: []
     plan: starter

--- a/render.yaml
+++ b/render.yaml
@@ -21,7 +21,7 @@ services:
       # Production Database (Supabase recommended)
       - key: DATABASE_URL
         sync: false
-      # Redis for session/cache
+        sync: false  # Set in Render dashboard
       - key: REDIS_URL
         sync: false
       # Supabase Config

--- a/render.yaml
+++ b/render.yaml
@@ -46,7 +46,7 @@ services:
 
   # Redis Cache (Render Managed Redis)
     ipAllowList: []  # Allow all (required for Render services)
-    name: poker-redis
+    plan: starter  # Free tier available
     ipAllowList: []
     plan: starter
     maxmemoryPolicy: allkeys-lru

--- a/render.yaml
+++ b/render.yaml
@@ -41,7 +41,7 @@ services:
         value: wss://poker-backend.onrender.com
       - key: JWT_AUDIENCE
         value: authenticated
-    healthCheckPath: /health
+    plan: starter  # Hobby plan ($7/mo minimum for always-on)
     plan: starter
 
   # Redis Cache (Render Managed Redis)

--- a/render.yaml
+++ b/render.yaml
@@ -20,10 +20,10 @@ services:
           envVarKey: PORT
       # Production Database (Supabase recommended)
       - key: DATABASE_URL
-        sync: false  # Set in Render dashboard
+        sync: false
       # Redis for session/cache
       - key: REDIS_URL
-        sync: false  # Set in Render dashboard or use Render Redis
+        sync: false
       # Supabase Config
       - key: SUPABASE_URL
         sync: false
@@ -42,35 +42,11 @@ services:
       - key: JWT_AUDIENCE
         value: authenticated
     healthCheckPath: /health
-    # WebSocket support
-    env: node
-    plan: starter  # Hobby plan ($7/mo minimum for always-on)
-    
-    
-  - type: static
-    name: poker-frontend
-    runtime: static
-    repo: https://github.com/rmeyer1/demo
-    branch: main
-    buildCommand: cd frontend && npm install && npm run build
-    publish: frontend/dist
-    envVars:
-      - key: NEXT_PUBLIC_SUPABASE_URL
-        sync: false
-      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
-    publish: frontend/.next
-      - key: NEXT_PUBLIC_API_BASE_URL
-        value: https://poker-backend.onrender.com
-      - key: NODE_ENV
-        value: production
-    headers:
-      - path: /*
-        name: Cache-Control
-        value: public, max-age=0, must-revalidate
-    
+    plan: starter
+
   # Redis Cache (Render Managed Redis)
   - type: redis
     name: poker-redis
-    ipAllowList: []  # Allow all (required for Render services)
-    plan: starter  # Free tier available
+    ipAllowList: []
+    plan: starter
     maxmemoryPolicy: allkeys-lru


### PR DESCRIPTION
## Problem
The current render.yaml has validation errors preventing deployment:
1. Invalid `env: node` property (not supported)
2. Malformed frontend config with duplicates
3. Extra unnecessary lines

## Solution
- Removed invalid `env: node` field
- Removed frontend static site (using Vercel per DEPLOY.md)
- Cleaned YAML formatting
- Backend + Redis service only

## Related
- PR #71 (merged) - Original setup
- DEPLOY.md - Vercel + Render guide